### PR TITLE
Array reactivity

### DIFF
--- a/packages/core/src/getters/route.test.ts
+++ b/packages/core/src/getters/route.test.ts
@@ -1,4 +1,4 @@
-import { getRoute } from './route';
+import { getRoute, getRouteArray } from './route';
 
 describe('getRoute getter', () => {
   [
@@ -15,6 +15,28 @@ describe('getRoute getter', () => {
   ].forEach(([input, expected]) => {
     it(`should process ${input} to ${expected}`, () => {
       expect(getRoute(input)).toBe(expected);
+    });
+  });
+});
+
+describe('getRouteArray getter', () => {
+  [
+    ['/api/test/{id}', ['/api/test/', '${id}']],
+    ['/api/test/{path*}', ['/api/test/', '${path}']],
+    ['/api/test/{user_id}', ['/api/test/', '${userId}']],
+    ['/api/test/{locale}.js', ['/api/test/', '${locale}', '.js']],
+    ['/api/test/i18n-{locale}.js', ['/api/test/i18n-', '${locale}', '.js']],
+    [
+      '/api/test/{param1}-{param2}.js',
+      ['/api/test/', '${param1}', '-', '${param2}', '.js'],
+    ],
+    [
+      '/api/test/user{param1}-{param2}.html',
+      ['/api/test/user', '${param1}', '-', '${param2}', '.html'],
+    ],
+  ].forEach(([input, expected]) => {
+    it(`should process ${input} to ${expected}`, () => {
+      expect(getRouteArray(input)).toStrictEqual(expected);
     });
   });
 });

--- a/packages/core/src/getters/route.ts
+++ b/packages/core/src/getters/route.ts
@@ -37,3 +37,33 @@ export const getRoute = (route: string) => {
     return `${acc}/${getRoutePath(path)}`;
   }, '');
 };
+
+// transform "blabla{param}" string into ["blabla", "${param}"] array
+export function getRouteArray(input: string): string[] {
+  const output = [];
+  let current = '';
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (char === '{') {
+      output.push(current);
+      current = '';
+    }
+
+    current += char;
+
+    if (char === '}') {
+      output.push(getRoutePath(current));
+      current = '';
+    }
+  }
+
+  if (current) {
+    output.push(current);
+  }
+
+  console.log({ input, output });
+
+  return output;
+}

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -29,11 +29,12 @@ import {
   toObjectString,
   Verbs,
   VERBS_WITH_BODY,
+  getRouteArray,
 } from '@orval/core';
 import omitBy from 'lodash.omitby';
 import {
   normalizeQueryOptions,
-  makeVueRouteReactive,
+  handleReactiveVueRoute,
   vueWrapTypeWithMaybeRef,
   isVue,
 } from './utils';
@@ -292,7 +293,7 @@ const generateQueryRequestFunction = (
 ) => {
   // Vue - Unwrap path params
   const route: string = isVue(outputClient)
-    ? makeVueRouteReactive(_route)
+    ? handleReactiveVueRoute(_route)
     : _route;
   const isRequestOptions = override.requestOptions !== false;
   const isFormData = override.formData !== false;
@@ -904,7 +905,7 @@ const generateQueryHook = async (
 ) => {
   // Vue - Unwrap path params
   const route: string = isVue(outputClient)
-    ? makeVueRouteReactive(_route)
+    ? handleReactiveVueRoute(_route)
     : _route;
   const query = override?.query;
   const isRequestOptions = override?.requestOptions !== false;
@@ -989,7 +990,13 @@ const generateQueryHook = async (
       queryKeyProps = vueWrapTypeWithMaybeRef(queryKeyProps);
     }
 
-    const queryKeyFn = `export const ${queryKeyFnName} = (${queryKeyProps}) => [\`${route}\`${
+    const routeString = isVue(outputClient)
+      ? getRouteArray(_route.replace(/\${/g, '{'))
+          .map((x) => `\`${x}\``)
+          .join(', ')
+      : `\`${route}\``;
+
+    const queryKeyFn = `export const ${queryKeyFnName} = (${queryKeyProps}) => [${routeString}${
       queryParams ? ', ...(params ? [params]: [])' : ''
     }${body.implementation ? `, ${body.implementation}` : ''}] as const;`;
 

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -402,10 +402,11 @@ const generateQueryRequestFunction = (
     hasSignal,
   });
 
-  return `export const ${operationName} = (\n    ${toObjectString(
-    props,
-    'implementation',
-  )} ${optionsArgs} ): Promise<AxiosResponse<${
+  const queryProps = isVue(outputClient)
+    ? vueWrapTypeWithMaybeRef(toObjectString(props, 'implementation'))
+    : toObjectString(props, 'implementation');
+
+  return `export const ${operationName} = (\n    ${queryProps} ${optionsArgs} ): Promise<AxiosResponse<${
     response.definition.success || 'unknown'
   }>> => {${bodyForm}
     return axios${

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -992,7 +992,9 @@ const generateQueryHook = async (
 
     const routeString = isVue(outputClient)
       ? getRouteArray(_route.replace(/\${/g, '{'))
-          .map((x) => `\`${x}\``)
+          .map((x) =>
+            x.startsWith('${') ? x.substring(2, x.length - 1) : `\`${x}\``,
+          )
           .join(', ')
       : `\`${route}\``;
 

--- a/packages/query/src/utils.ts
+++ b/packages/query/src/utils.ts
@@ -99,7 +99,7 @@ export function vueWrapTypeWithMaybeRef(input: string): string {
 }
 
 // Vue persist reactivity
-export const makeVueRouteReactive = (route: string): string =>
+export const handleReactiveVueRoute = (route: string): string =>
   (route ?? '').replaceAll(/\${(\w+)}/g, '${unref($1)}');
 
 export const isVue = (client: OutputClient | OutputClientFunc) =>

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -49,7 +49,7 @@ export const listPets = (
 export const getListPetsQueryKey = (
   params?: MaybeRef<ListPetsParams>,
   version = 1,
-) => [`/v${unref(version)}/pets`, ...(params ? [params] : [])] as const;
+) => [`/v`, `${version}`, `/pets`, ...(params ? [params] : [])] as const;
 
 export const getListPetsInfiniteQueryOptions = <
   TData = Awaited<ReturnType<typeof listPets>>,
@@ -253,7 +253,7 @@ export const showPetById = (
 };
 
 export const getShowPetByIdQueryKey = (petId: MaybeRef<string>, version = 1) =>
-  [`/v${unref(version)}/pets/${unref(petId)}`] as const;
+  [`/v`, `${version}`, `/pets/`, `${petId}`] as const;
 
 export const getShowPetByIdInfiniteQueryOptions = <
   TData = Awaited<ReturnType<typeof showPetById>>,

--- a/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
+++ b/samples/vue-query/src/api/endpoints/petstoreFromFileSpecWithTransformer.ts
@@ -49,7 +49,7 @@ export const listPets = (
 export const getListPetsQueryKey = (
   params?: MaybeRef<ListPetsParams>,
   version = 1,
-) => [`/v`, `${version}`, `/pets`, ...(params ? [params] : [])] as const;
+) => [`/v`, version, `/pets`, ...(params ? [params] : [])] as const;
 
 export const getListPetsInfiniteQueryOptions = <
   TData = Awaited<ReturnType<typeof listPets>>,
@@ -253,7 +253,7 @@ export const showPetById = (
 };
 
 export const getShowPetByIdQueryKey = (petId: MaybeRef<string>, version = 1) =>
-  [`/v`, `${version}`, `/pets/`, `${petId}`] as const;
+  [`/v`, version, `/pets/`, petId] as const;
 
 export const getShowPetByIdInfiniteQueryOptions = <
   TData = Awaited<ReturnType<typeof showPetById>>,


### PR DESCRIPTION
Does 
```ts
[`/v`, version, `/pets`]
```
instead of 
```ts
[`/v${unref(version)}/pets`]
```
to preserve reactivity.

Quite dirty, but seems to work.